### PR TITLE
fix(README.md): Update `paper` and `blog` Link URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ we're jamming in other ways now too.
 
 - we're building [nudel](https://github.com/pastagang/nudel) together.
 - we're building more things like [spag](https://github.com/pastagang/spag) on our [github](https://github.com/pastagang).
-- we're writing a [paper](https://github.com/pastagang/pastagang/edit/main/paper/readme.md)
-- we're starting a [blog](https://github.com/pastagang/pastagang/edit/main/blog/let-code-die/readme.md)
+- we're writing a [paper](https://github.com/pastagang/pastagang/blob/main/paper/readme.md)
+- we're starting a [blog](https://github.com/pastagang/pastagang/blob/main/blog/let-code-die/readme.md)
 - we gather youtube recordings on our [playlist](https://www.youtube.com/playlist?list=PL9uRa69RF-7wOS5CnK0wy34t5HYgFLIng)
 
 you are invited to join all of these.\


### PR DESCRIPTION
Firstly, _excellent_ posts — love 'em!

This small fix ensures that any person who follows either of the `paper` or `blog` link URLs will be able to immediately read the most up-to-date `paper` and `blog` posts on `main`.

Currently, the `paper` and `blog` link URLs open in GitHub's file editor.
Because of this, if the person following either of those links:

a. isn't authenticated, or
b. is authenticated, but doesn't have a `pastagang` fork

then they'll need to:

a. login and navigate back to the respective `readme.md` file, or
b. navigate back to the respective `readme.md` file.